### PR TITLE
Add Jsend and Base Response classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,17 @@ The following versions of PHP are supported by this version.
 * PHP 5.5
 * PHP 5.6
 
+## Features 
+
+The following are available:
+
+* HttpClient
+* Oauth2Client
+* HttpResponse
+
 ## Todo
 
 - Add Adapters
-- Add Response Handlers
 
 ## Change log
 

--- a/src/HttpResponse/BaseResponse.php
+++ b/src/HttpResponse/BaseResponse.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace CottaCush\Yii2\HttpResponse;
+
+use yii\helpers\ArrayHelper;
+
+/**
+ * Class BaseResponse
+ * @package app\libs
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+abstract class BaseResponse
+{
+    protected $rawResponse;
+    protected $parsedResponse;
+    protected $responseParsed = true;
+
+    /**
+     * BaseResponse constructor.
+     * @param $response
+     * @author Adegoke Obasa <goke@cottacush.com>
+     */
+    public function __construct($response)
+    {
+        $this->rawResponse = $this->parsedResponse = $response;
+    }
+
+    /**
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function getRawResponse()
+    {
+        return $this->rawResponse;
+    }
+
+    /**
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return \SimpleXMLElement
+     */
+    public function getParsedResponse()
+    {
+        return $this->parsedResponse;
+    }
+
+    /**
+     * Returns true if response is a success response
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function isSuccess()
+    {
+        return ArrayHelper::getValue($this->parsedResponse, $this->getStatusParam()) == $this->getSuccessValue();
+    }
+
+    /**
+     * Gets the value of key if key exists, default value otherwise
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @param $key
+     * @param null $default
+     * @return mixed
+     */
+    abstract public function get($key, $default = null);
+
+    /**
+     * Returns the Status parameter
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    abstract public function getStatusParam();
+
+    /**
+     * Returns the value for a success status
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    abstract public function getSuccessValue();
+
+    /**
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @param boolean $responseParsed
+     * @return BaseResponse
+     */
+    public function setResponseParsed($responseParsed)
+    {
+        $this->responseParsed = $responseParsed;
+        return $this;
+    }
+
+    /**
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return boolean
+     */
+    public function isResponseParsed()
+    {
+        return $this->responseParsed;
+    }
+}

--- a/src/HttpResponse/BaseResponse.php
+++ b/src/HttpResponse/BaseResponse.php
@@ -13,7 +13,10 @@ abstract class BaseResponse
 {
     protected $rawResponse;
     protected $parsedResponse;
-    protected $responseParsed = true;
+    /**
+     * @var bool Whether response has already been parsed or not
+     */
+    protected $responseParsed;
 
     /**
      * BaseResponse constructor.
@@ -21,7 +24,7 @@ abstract class BaseResponse
      * @param bool $responseParsed
      * @author Adegoke Obasa <goke@cottacush.com>
      */
-    public function __construct($response, $responseParsed = false)
+    public function __construct($response, $responseParsed = true)
     {
         $this->rawResponse = $this->parsedResponse = $response;
         $this->responseParsed = $responseParsed;

--- a/src/HttpResponse/BaseResponse.php
+++ b/src/HttpResponse/BaseResponse.php
@@ -18,11 +18,13 @@ abstract class BaseResponse
     /**
      * BaseResponse constructor.
      * @param $response
+     * @param bool $responseParsed
      * @author Adegoke Obasa <goke@cottacush.com>
      */
-    public function __construct($response)
+    public function __construct($response, $responseParsed = false)
     {
         $this->rawResponse = $this->parsedResponse = $response;
+        $this->responseParsed = $responseParsed;
     }
 
     /**
@@ -36,7 +38,7 @@ abstract class BaseResponse
 
     /**
      * @author Adegoke Obasa <goke@cottacush.com>
-     * @return \SimpleXMLElement
+     * @return mixed
      */
     public function getParsedResponse()
     {
@@ -75,17 +77,6 @@ abstract class BaseResponse
      * @return mixed
      */
     abstract public function getSuccessValue();
-
-    /**
-     * @author Adegoke Obasa <goke@cottacush.com>
-     * @param boolean $responseParsed
-     * @return BaseResponse
-     */
-    public function setResponseParsed($responseParsed)
-    {
-        $this->responseParsed = $responseParsed;
-        return $this;
-    }
 
     /**
      * @author Adegoke Obasa <goke@cottacush.com>

--- a/src/HttpResponse/JSendResponse.php
+++ b/src/HttpResponse/JSendResponse.php
@@ -14,6 +14,8 @@ class JSendResponse extends BaseResponse
 
     const RESPONSE_STATUS_PARAM = 'status';
     const RESPONSE_DATA_PARAM = 'data';
+    const RESPONSE_CODE_PARAM = 'code';
+    const RESPONSE_MESSAGE_PARAM = 'message';
     const RESPONSE_STATUS_SUCCESS = 'success';
     const RESPONSE_STATUS_OK = 'OK';
     const CODE_NO_CODE = '000';
@@ -22,51 +24,47 @@ class JSendResponse extends BaseResponse
     protected $rawResponse;
     protected $responseParsed = false;
 
-    public function __construct($response)
+    public function __construct($response, $responseParsed = false)
     {
-        parent::__construct($response);
+        parent::__construct($response, $responseParsed);
         if ($this->responseParsed) {
             $this->parsedResponse = Json::decode($response);
         }
     }
 
     /**
-     * Get's the data from the response
+     * Gets the data from the response
      * @author Adegoke Obasa <goke@cottacush.com>
-     * @author Adeyemi Olaoye <yemi@cottacush.com>
-     * @param null $field
-     * @param string $dataKey
+     * @param null $defaultValue
      * @return mixed
      */
-    public function getData($field = null, $dataKey = 'data')
+    public function getData($defaultValue = null)
     {
-        if (is_null($field)) {
-            $field = $dataKey;
-        } else {
-            $field = $dataKey . '.' . $field;
-        }
-
-        return ArrayHelper::getValue($this->rawResponse, $field);
+        return ArrayHelper::getValue($this->parsedResponse, self::RESPONSE_DATA_PARAM, $defaultValue);
     }
 
     /**
-     * Get's the error message from the response
+     * Gets the error message from the response
      * @author Adegoke Obasa <goke@cottacush.com>
      * @return mixed
      */
     public function getErrorMessage()
     {
-        return ArrayHelper::getValue($this->rawResponse, 'message', self::ERROR_MESSAGE_AN_UNEXPECTED_ERROR_OCCURRED);
+        return ArrayHelper::getValue(
+            $this->parsedResponse,
+            self::RESPONSE_MESSAGE_PARAM,
+            self::ERROR_MESSAGE_AN_UNEXPECTED_ERROR_OCCURRED
+        );
     }
 
     /**
-     * Get's the response code from the response
+     * Gets the response code from the response
      * @author Adegoke Obasa <goke@cottacush.com>
      * @return mixed
      */
     public function getCode()
     {
-        return ArrayHelper::getValue($this->rawResponse, 'code', self::CODE_NO_CODE);
+        return ArrayHelper::getValue($this->parsedResponse, self::RESPONSE_CODE_PARAM, self::CODE_NO_CODE);
     }
 
     /**
@@ -103,5 +101,25 @@ class JSendResponse extends BaseResponse
     public function getSuccessValue()
     {
         return self::RESPONSE_STATUS_SUCCESS;
+    }
+
+    /**
+     * Gets the code parameter
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return string
+     */
+    public function getCodeParam()
+    {
+        return self::RESPONSE_CODE_PARAM;
+    }
+
+    /**
+     * Gets the message parameter
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return string
+     */
+    public function getMessageParam()
+    {
+        return self::RESPONSE_MESSAGE_PARAM;
     }
 }

--- a/src/HttpResponse/JSendResponse.php
+++ b/src/HttpResponse/JSendResponse.php
@@ -1,0 +1,107 @@
+<?php
+namespace CottaCush\Yii2\HttpResponse;
+
+use yii\helpers\ArrayHelper;
+use yii\helpers\Json;
+
+/**
+ * Class JSendResponseHandler
+ * @package app\libs
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+class JSendResponseHandler extends BaseResponse
+{
+
+    const RESPONSE_STATUS_PARAM = 'status';
+    const RESPONSE_DATA_PARAM = 'data';
+    const RESPONSE_STATUS_SUCCESS = 'success';
+    const RESPONSE_STATUS_OK = 'OK';
+    const CODE_NO_CODE = '000';
+    const ERROR_MESSAGE_AN_UNEXPECTED_ERROR_OCCURRED = 'An unexpected error occurred';
+
+    protected $rawResponse;
+    protected $responseParsed = false;
+
+    public function __construct($response)
+    {
+        parent::__construct($response);
+        if ($this->responseParsed) {
+            $this->parsedResponse = Json::decode($response);
+        }
+    }
+
+    /**
+     * Get's the data from the response
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @author Adeyemi Olaoye <yemi@cottacush.com>
+     * @param null $field
+     * @param string $dataKey
+     * @return mixed
+     */
+    public function getData($field = null, $dataKey = 'data')
+    {
+        if (is_null($field)) {
+            $field = $dataKey;
+        } else {
+            $field = $dataKey . '.' . $field;
+        }
+
+        return ArrayHelper::getValue($this->rawResponse, $field);
+    }
+
+    /**
+     * Get's the error message from the response
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function getErrorMessage()
+    {
+        return ArrayHelper::getValue($this->rawResponse, 'message', self::ERROR_MESSAGE_AN_UNEXPECTED_ERROR_OCCURRED);
+    }
+
+    /**
+     * Get's the response code from the response
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function getCode()
+    {
+        return ArrayHelper::getValue($this->rawResponse, 'code', self::CODE_NO_CODE);
+    }
+
+    /**
+     * Gets the value of key if key exists, default value otherwise
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @param $key
+     * @param null $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return ArrayHelper::getValue(
+            $this->parsedResponse,
+            sprintf('%s.%s', self::RESPONSE_DATA_PARAM, $key),
+            $default
+        );
+    }
+
+    /**
+     * Returns the Status parameter
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function getStatusParam()
+    {
+        return self::RESPONSE_STATUS_PARAM;
+    }
+
+    /**
+     * Returns the value for a success status
+     * @author Adegoke Obasa <goke@cottacush.com>
+     * @return mixed
+     */
+    public function getSuccessValue()
+    {
+        return self::RESPONSE_STATUS_SUCCESS;
+    }
+}

--- a/src/HttpResponse/JSendResponse.php
+++ b/src/HttpResponse/JSendResponse.php
@@ -11,7 +11,6 @@ use yii\helpers\Json;
  */
 class JSendResponse extends BaseResponse
 {
-
     const RESPONSE_STATUS_PARAM = 'status';
     const RESPONSE_DATA_PARAM = 'data';
     const RESPONSE_CODE_PARAM = 'code';

--- a/src/HttpResponse/JSendResponse.php
+++ b/src/HttpResponse/JSendResponse.php
@@ -5,11 +5,11 @@ use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 
 /**
- * Class JSendResponseHandler
+ * Class JSendResponse
  * @package app\libs
  * @author Adegoke Obasa <goke@cottacush.com>
  */
-class JSendResponseHandler extends BaseResponse
+class JSendResponse extends BaseResponse
 {
 
     const RESPONSE_STATUS_PARAM = 'status';

--- a/src/HttpResponse/JSendResponse.php
+++ b/src/HttpResponse/JSendResponse.php
@@ -23,10 +23,10 @@ class JSendResponse extends BaseResponse
     protected $rawResponse;
     protected $responseParsed = false;
 
-    public function __construct($response, $responseParsed = false)
+    public function __construct($response, $responseParsed = true)
     {
         parent::__construct($response, $responseParsed);
-        if ($this->responseParsed) {
+        if (!$this->responseParsed) {
             $this->parsedResponse = Json::decode($response);
         }
     }

--- a/tests/HttpResponse/JSendResponseTest.php
+++ b/tests/HttpResponse/JSendResponseTest.php
@@ -1,0 +1,201 @@
+<?php
+namespace CottaCush\Yii2\Tests\HttpResponse;
+
+use CottaCush\Yii2\HttpResponse\JSendResponse;
+use Faker\Factory;
+use Faker\Generator;
+
+/**
+ * Class JSendResponseTest
+ * @package CottaCush\Yii2\Tests\HttpResponse
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+class JSendResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Generator $faker */
+    protected $faker;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->faker = Factory::create();
+    }
+
+    public function testGetResponseParsedIsFalseByDefault()
+    {
+        $jsonResponse = new JSendResponse([]);
+        $this->assertEquals($jsonResponse->isResponseParsed(), false);
+    }
+
+    public function testGetResponseParsedIsActualValueSet()
+    {
+        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $this->assertEquals($jsonResponse->isResponseParsed(), true);
+    }
+
+    public function testResponseRawResponseIsSet()
+    {
+        $words = $this->faker->words;
+
+        $rawResponse = json_encode($words);
+        $jsonResponse = new JSendResponse(json_encode($words));
+        $this->assertEquals($jsonResponse->getRawResponse(), $rawResponse);
+    }
+
+    public function testResponseParsedResponseIsSetWhenNotParsed()
+    {
+        $words = $this->faker->words;
+
+        $rawResponse = json_encode($words);
+        $jsonResponse = new JSendResponse(json_encode($words));
+        $this->assertEquals($jsonResponse->getParsedResponse(), $rawResponse);
+    }
+
+    public function testResponseParsedResponseIsSetWhenParsed()
+    {
+        $words = $this->faker->words;
+
+        $jsonResponse = new JSendResponse(json_encode($words), true);
+        $this->assertEquals($jsonResponse->getParsedResponse(), $words);
+    }
+
+    public function testStatusParamIsCorrect()
+    {
+        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $this->assertEquals($jsonResponse->getStatusParam(), JSendResponse::RESPONSE_STATUS_PARAM);
+    }
+
+    public function testCodeParamIsCorrect()
+    {
+        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $this->assertEquals($jsonResponse->getCodeParam(), JSendResponse::RESPONSE_CODE_PARAM);
+    }
+
+    public function testMessageParamIsCorrect()
+    {
+        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $this->assertEquals($jsonResponse->getMessageParam(), JSendResponse::RESPONSE_MESSAGE_PARAM);
+    }
+
+    public function testSuccessValueIsCorrect()
+    {
+        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $this->assertEquals($jsonResponse->getSuccessValue(), JSendResponse::RESPONSE_STATUS_SUCCESS);
+    }
+
+    public function testIsSuccessReturnsTrueWhenStatusIsSuccessWhenResponseIsParsed()
+    {
+        $jsonResponse = new JSendResponse(json_encode(['status' => JSendResponse::RESPONSE_STATUS_SUCCESS]), true);
+        $this->assertEquals($jsonResponse->isSuccess(), true);
+    }
+
+    public function testIsSuccessReturnsTrueWhenStatusIsSuccessWhenResponseNotParsed()
+    {
+        $jsonResponse = new JSendResponse(['status' => JSendResponse::RESPONSE_STATUS_SUCCESS]);
+        $this->assertEquals($jsonResponse->isSuccess(), true);
+    }
+
+    public function testIsSuccessReturnsFalseWhenStatusIsSuccessWhenResponseIsParsed()
+    {
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), true);
+        $this->assertEquals($jsonResponse->isSuccess(), false);
+    }
+
+    public function testIsSuccessReturnsFalseWhenStatusIsSuccessWhenResponseNotParsed()
+    {
+        $jsonResponse = new JSendResponse(['status' => 'error']);
+        $this->assertEquals($jsonResponse->isSuccess(), false);
+    }
+
+    public function testGetErrorMessageWhenResponseIsNotParsed()
+    {
+        $message = $this->faker->sentence;
+        $jsonResponse = new JSendResponse(['status' => 'error', 'message' => $message]);
+        $this->assertEquals($jsonResponse->getErrorMessage(), $message);
+    }
+
+    public function testGetErrorMessageWhenResponseIsParsed()
+    {
+        $message = $this->faker->sentence;
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'message' => $message]), true);
+        $this->assertEquals($jsonResponse->getErrorMessage(), $message);
+    }
+
+    public function testGetCodeWhenResponseIsNotParsed()
+    {
+        $code = $this->faker->randomDigitNotNull;
+        $jsonResponse = new JSendResponse(['status' => 'error', 'code' => $code]);
+        $this->assertEquals($jsonResponse->getCode(), $code);
+    }
+
+    public function testGetCodeWhenResponseIsParsed()
+    {
+        $code = $this->faker->randomDigitNotNull;
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'code' => $code]), true);
+        $this->assertEquals($jsonResponse->getCode(), $code);
+    }
+
+    public function testGetCodeWhenNotSetAndResponseIsNotParsed()
+    {
+        $jsonResponse = new JSendResponse(['status' => 'error']);
+        $this->assertEquals($jsonResponse->getCode(), JSendResponse::CODE_NO_CODE);
+    }
+
+    public function testGetCodeWhenSetAndResponseIsParsed()
+    {
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), true);
+        $this->assertEquals($jsonResponse->getCode(), JSendResponse::CODE_NO_CODE);
+    }
+
+    public function testGetDataWhenResponseIsNotParsed()
+    {
+        $words = $this->faker->words;
+        $jsonResponse = new JSendResponse(['status' => 'success', 'data' => $words]);
+        $this->assertEquals($jsonResponse->getData(), $words);
+    }
+
+    public function testGetDataWhenResponseIsParsed()
+    {
+        $words = $this->faker->words;
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => $words]), true);
+        $this->assertEquals($jsonResponse->getData(), $words);
+    }
+
+    public function testGetDataWhenNotSetAndResponseIsNotParsed()
+    {
+        $jsonResponse = new JSendResponse(['status' => 'success']);
+        $this->assertEquals($jsonResponse->getData([]), []);
+    }
+
+    public function testGetDataWhenNotSetAndResponseIsParsed()
+    {
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), true);
+        $this->assertEquals($jsonResponse->getData([]), []);
+    }
+
+    public function testGetWhenResponseIsNotParsed()
+    {
+        $words = $this->faker->words;
+        $jsonResponse = new JSendResponse(['status' => 'success', 'data' => compact('words')]);
+        $this->assertEquals($jsonResponse->get('words'), $words);
+    }
+
+    public function testGetWhenResponseIsParsed()
+    {
+        $words = $this->faker->words;
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => compact('words')]), true);
+        $this->assertEquals($jsonResponse->get('words'), $words);
+    }
+
+    public function testGetWhenNotSetAndResponseIsNotParsed()
+    {
+        $jsonResponse = new JSendResponse(['status' => 'success']);
+        $this->assertEquals($jsonResponse->get('words', []), []);
+    }
+
+    public function testGetWhenNotSetAndResponseIsParsed()
+    {
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), true);
+        $this->assertEquals($jsonResponse->get('words', []), []);
+    }
+}

--- a/tests/HttpResponse/JSendResponseTest.php
+++ b/tests/HttpResponse/JSendResponseTest.php
@@ -24,13 +24,13 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetResponseParsedIsFalseByDefault()
     {
         $jsonResponse = new JSendResponse([]);
-        $this->assertEquals($jsonResponse->isResponseParsed(), false);
+        $this->assertEquals($jsonResponse->isResponseParsed(), true);
     }
 
     public function testGetResponseParsedIsActualValueSet()
     {
-        $jsonResponse = new JSendResponse(json_encode([]), true);
-        $this->assertEquals($jsonResponse->isResponseParsed(), true);
+        $jsonResponse = new JSendResponse(json_encode([]), false);
+        $this->assertEquals($jsonResponse->isResponseParsed(), false);
     }
 
     public function testResponseRawResponseIsSet()
@@ -55,37 +55,37 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     {
         $words = $this->faker->words;
 
-        $jsonResponse = new JSendResponse(json_encode($words), true);
+        $jsonResponse = new JSendResponse(json_encode($words), false);
         $this->assertEquals($jsonResponse->getParsedResponse(), $words);
     }
 
     public function testStatusParamIsCorrect()
     {
-        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $jsonResponse = new JSendResponse(json_encode([]), false);
         $this->assertEquals($jsonResponse->getStatusParam(), JSendResponse::RESPONSE_STATUS_PARAM);
     }
 
     public function testCodeParamIsCorrect()
     {
-        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $jsonResponse = new JSendResponse(json_encode([]), false);
         $this->assertEquals($jsonResponse->getCodeParam(), JSendResponse::RESPONSE_CODE_PARAM);
     }
 
     public function testMessageParamIsCorrect()
     {
-        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $jsonResponse = new JSendResponse(json_encode([]), false);
         $this->assertEquals($jsonResponse->getMessageParam(), JSendResponse::RESPONSE_MESSAGE_PARAM);
     }
 
     public function testSuccessValueIsCorrect()
     {
-        $jsonResponse = new JSendResponse(json_encode([]), true);
+        $jsonResponse = new JSendResponse(json_encode([]), false);
         $this->assertEquals($jsonResponse->getSuccessValue(), JSendResponse::RESPONSE_STATUS_SUCCESS);
     }
 
     public function testIsSuccessReturnsTrueWhenStatusIsSuccessWhenResponseIsParsed()
     {
-        $jsonResponse = new JSendResponse(json_encode(['status' => JSendResponse::RESPONSE_STATUS_SUCCESS]), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => JSendResponse::RESPONSE_STATUS_SUCCESS]), false);
         $this->assertEquals($jsonResponse->isSuccess(), true);
     }
 
@@ -97,7 +97,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testIsSuccessReturnsFalseWhenStatusIsSuccessWhenResponseIsParsed()
     {
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), false);
         $this->assertEquals($jsonResponse->isSuccess(), false);
     }
 
@@ -117,7 +117,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetErrorMessageWhenResponseIsParsed()
     {
         $message = $this->faker->sentence;
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'message' => $message]), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'message' => $message]), false);
         $this->assertEquals($jsonResponse->getErrorMessage(), $message);
     }
 
@@ -131,7 +131,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetCodeWhenResponseIsParsed()
     {
         $code = $this->faker->randomDigitNotNull;
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'code' => $code]), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error', 'code' => $code]), false);
         $this->assertEquals($jsonResponse->getCode(), $code);
     }
 
@@ -143,7 +143,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCodeWhenSetAndResponseIsParsed()
     {
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'error']), false);
         $this->assertEquals($jsonResponse->getCode(), JSendResponse::CODE_NO_CODE);
     }
 
@@ -157,7 +157,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetDataWhenResponseIsParsed()
     {
         $words = $this->faker->words;
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => $words]), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => $words]), false);
         $this->assertEquals($jsonResponse->getData(), $words);
     }
 
@@ -169,7 +169,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDataWhenNotSetAndResponseIsParsed()
     {
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), false);
         $this->assertEquals($jsonResponse->getData([]), []);
     }
 
@@ -183,7 +183,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetWhenResponseIsParsed()
     {
         $words = $this->faker->words;
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => compact('words')]), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success', 'data' => compact('words')]), false);
         $this->assertEquals($jsonResponse->get('words'), $words);
     }
 
@@ -195,7 +195,7 @@ class JSendResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWhenNotSetAndResponseIsParsed()
     {
-        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), true);
+        $jsonResponse = new JSendResponse(json_encode(['status' => 'success']), false);
         $this->assertEquals($jsonResponse->get('words', []), []);
     }
 }


### PR DESCRIPTION
This PR adds two HttpResponse classes. 
1. BaseResponse - Abstract class, new HttpResponse classes would be expected to extend this class.
2. JSendResponse - [JSend](https://labs.omniti.com/labs/jsend) implementation of the BaseResponse class. 

Tests
- Tests have been written for every method in the two classes and the code coverage stands at 100% now.

Cheers 
