### PR TITLE
Allow PHP version 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -17,6 +19,12 @@ cache:
 matrix:
   include:
     - php: 5.5
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 5.6
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 7.0
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 7.1
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php" : "~5.5",
+        "php" : "~5.5|~7.0",
         "yiisoft/yii2": ">=2.0.8",
         "linslin/yii2-curl" : "*",
         "yiisoft/yii2-authclient": "~2.0.0",


### PR DESCRIPTION
This PR allows for PHP version 7, this is needed for the docker setup being done on the Yii2-base-project as this libraries doesn't allow the composer installtion to go through.